### PR TITLE
Align auth templates with landing layout

### DIFF
--- a/templates/accounts/password_reset_done.html
+++ b/templates/accounts/password_reset_done.html
@@ -1,22 +1,58 @@
-{% extends "base.html" %}
 {% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Instructions Sent - Moohaar</title>
 
-{% block title %}Instructions Sent - Moohaar{% endblock title %}
+  <!-- Landing-page styles (for header/footer) -->
+  <link rel="stylesheet" href="{% static 'css/landing_page.css' %}">
+  <!-- Auth-page overrides -->
+  <link rel="stylesheet" href="{% static 'css/auth_styles.css' %}">
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Nastaliq+Urdu:wght@400;700&family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
 
-{% block extra_head %}
-    <link rel="stylesheet" href="{% static 'css/auth_styles.css' %}">
-{% endblock extra_head %}
+  <!-- landing header -->
+  <header class="landing-header">
+    <nav class="container landing-nav">
+      <div class="landing-logo"><a href="{% url 'platform_home' %}">Moohaar</a></div>
+      <div class="landing-nav-links">
+        <a href="#">Features</a>
+        <a href="#">Pricing</a>
+        <a href="{% url 'login' %}">Login</a>
+        <a href="{% url 'register' %}" class="button button-cta">Sign Up</a>
+      </div>
+    </nav>
+  </header>
 
-{% block auth_content %}
-<div class="auth-page-wrapper">
+  <!-- message card -->
+  <div class="auth-page-wrapper">
     <div class="auth-form-card">
-        <h2>Check Your Inbox</h2>
-        <p style="text-align: center; line-height: 1.6;">
-            We've emailed you instructions for setting your password. If an account exists with the email you entered, you should receive them shortly.
-        </p>
-        <p style="text-align: center; font-size: 0.9em; color: var(--text-muted);">
-            If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.
-        </p>
+      <h2>Check Your Inbox</h2>
+      <p style="text-align: center; line-height: 1.6;">
+        We've emailed you instructions for setting your password. If an account exists with the email you entered, you should receive them shortly.
+      </p>
+      <p style="text-align: center; font-size: 0.9em; color: var(--text-muted);">
+        If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder.
+      </p>
     </div>
-</div>
-{% endblock auth_content %}
+  </div>
+
+  <!-- landing footer -->
+  <footer class="landing-footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="#">About</a>
+        <a href="#">Privacy Policy</a>
+        <a href="#">Terms of Service</a>
+      </div>
+      <p>&copy; {% now "Y" %} Moohaar. All Rights Reserved.</p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update password reset done page to use the landing page header/footer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883551c85b4832e85490f5dbe74b193