### PR TITLE
Simplify theme switch

### DIFF
--- a/static/css/auth_styles.css
+++ b/static/css/auth_styles.css
@@ -71,7 +71,7 @@
     box-shadow: 0 0 0 2px rgba(41, 76, 116, 0.2);
 }
 
-html[data-theme="dark"] .form-field-wrapper input:focus {
+body.dark-mode .form-field-wrapper input:focus {
      box-shadow: 0 0 0 2px rgba(122, 160, 204, 0.25);
 }
 

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -18,7 +18,7 @@
     --stat-increase: #28a745;
     --stat-decrease: #dc3545;
 }
-html[data-theme="dark"] {
+body.dark-mode {
     --background: #131316;
     --sidebar-bg: #1c1c1f;
     --surface: #1c1c1f;
@@ -68,7 +68,7 @@ body {
 }
 .sidebar-link:hover { color: var(--text-primary); background-color: var(--background); }
 .sidebar-link.active { color: var(--text-on-accent); background-color: var(--accent); }
-html[data-theme="dark"] .sidebar-link.active { color: #1c1c1f; }
+body.dark-mode .sidebar-link.active { color: #1c1c1f; }
 .sidebar-link.disabled { color: var(--border); cursor: not-allowed; }
 .sidebar-link .icon { font-size: 1.1rem; width: 20px; text-align: center; }
 .badge.soon { font-size: 0.6rem; padding: 2px 5px; border-radius: 6px; background: var(--border); color: var(--text-secondary); margin-left: auto;}
@@ -105,7 +105,7 @@ html[data-theme="dark"] .sidebar-link.active { color: #1c1c1f; }
 .stat-card .stat-change { font-size: 0.8rem; font-weight: 500; }
 .stat-change.increase { color: var(--stat-increase); }
 .stat-change.decrease { color: var(--stat-decrease); }
-html[data-theme="dark"] .stat-card { background-color: var(--sidebar-bg); } 
+body.dark-mode .stat-card { background-color: var(--sidebar-bg); } 
 
 /* Chart Cards */
 .main-content-grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; }

--- a/static/css/product_detail_styles.css
+++ b/static/css/product_detail_styles.css
@@ -64,7 +64,7 @@
     display: flex; align-items: center; justify-content: center;
     position: relative; /* For image hover */
 }
-body[data-theme="dark"] .main-image-display-pdp {
+body.dark-mode .main-image-display-pdp {
     border-color: var(--theme-border-light);
     background-color: var(--theme-bg-light);
 }
@@ -105,7 +105,7 @@ body[data-theme="dark"] .main-image-display-pdp {
     border-top: 1px solid var(--theme-border-light);
     border-bottom: 1px solid var(--theme-border-light);
 }
-body[data-theme="dark"] .pdp-countdown-timer-wrapper { border-color: var(--theme-border-light); }
+body.dark-mode .pdp-countdown-timer-wrapper { border-color: var(--theme-border-light); }
 #pdpProductTimer { font-weight: bold; color: var(--theme-secondary-orange); letter-spacing: 0.5px; }
 
 .pdp-variants { margin-bottom: 1.5rem; }
@@ -119,14 +119,14 @@ body[data-theme="dark"] .pdp-countdown-timer-wrapper { border-color: var(--theme
 .pdp-color-swatches { display: flex; gap: 0.6rem; margin-top: 0.25rem; }
 .pdp-swatch { width: 24px; height: 24px; border-radius: 50%; border: 2px solid var(--theme-surface-light); cursor: pointer; transition: transform 0.2s ease, border-color 0.2s ease; box-shadow: 0 0 0 1px var(--theme-border-light); }
 .pdp-swatch.active, .pdp-swatch:hover { transform: scale(1.15); border-color: var(--theme-text-dark); }
-body[data-theme="dark"] .pdp-swatch { border: 2px solid var(--theme-surface-light); box-shadow: 0 0 0 1px var(--theme-border-light); }
-body[data-theme="dark"] .pdp-swatch.active, body[data-theme="dark"] .pdp-swatch:hover { border-color: var(--theme-text-dark); }
+body.dark-mode .pdp-swatch { border: 2px solid var(--theme-surface-light); box-shadow: 0 0 0 1px var(--theme-border-light); }
+body.dark-mode .pdp-swatch.active, body.dark-mode .pdp-swatch:hover { border-color: var(--theme-text-dark); }
 
 .pdp-size-options { display: flex; flex-wrap: wrap; gap: 0.5rem; }
 .pdp-size-btn { background-color: transparent; border: 1px solid var(--theme-input-border-color); color: var(--theme-text-muted); padding: 0.4em 0.8em; border-radius: 3px; cursor: pointer; font-size: 0.85em; transition: background-color 0.2s, color 0.2s, border-color 0.2s; min-width: 36px; text-align: center; }
 .pdp-size-btn.active, .pdp-size-btn:hover { background-color: var(--theme-text-dark); color: var(--theme-surface-light); border-color: var(--theme-text-dark); }
-body[data-theme="dark"] .pdp-size-btn { color: var(--theme-text-muted); border-color: var(--theme-input-border-color); }
-body[data-theme="dark"] .pdp-size-btn.active, body[data-theme="dark"] .pdp-size-btn:hover { background-color: var(--theme-text-dark); color: var(--theme-surface-light); border-color: var(--theme-text-dark); }
+body.dark-mode .pdp-size-btn { color: var(--theme-text-muted); border-color: var(--theme-input-border-color); }
+body.dark-mode .pdp-size-btn.active, body.dark-mode .pdp-size-btn:hover { background-color: var(--theme-text-dark); color: var(--theme-surface-light); border-color: var(--theme-text-dark); }
 
 .pdp-purchase-controls { margin-top: 1.5rem; display: flex; flex-direction: column; gap: 1rem; }
 .pdp-quantity-selector { display: flex; align-items: center; border: 1px solid var(--theme-input-border-color); border-radius: 4px; overflow: hidden; width: 110px; height: 40px; margin-bottom:0rem; } /* No margin if part of flex */
@@ -134,12 +134,12 @@ body[data-theme="dark"] .pdp-size-btn.active, body[data-theme="dark"] .pdp-size-
 .pdp-qty-btn:hover { color: var(--theme-text-dark); }
 #pdpProductQuantity { width: 30px; text-align: center; border: none; border-left: 1px solid var(--theme-input-border-color); border-right: 1px solid var(--theme-input-border-color); padding: 0.65rem 0; font-size: 0.9em; background-color: transparent; color: var(--theme-text-dark); -moz-appearance: textfield; height:100%; box-sizing: border-box;}
 #pdpProductQuantity::-webkit-outer-spin-button, #pdpProductQuantity::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-body[data-theme="dark"] #pdpProductQuantity { background-color: transparent; color: var(--theme-text-dark); border-color: var(--theme-input-border-color); }
+body.dark-mode #pdpProductQuantity { background-color: transparent; color: var(--theme-text-dark); border-color: var(--theme-input-border-color); }
 
 .add-to-cart-btn-pdp.button { padding: 0.85rem 1.5rem; font-size: 0.95em; font-weight: 600; text-transform: uppercase; background-color: var(--theme-text-dark); color: var(--theme-surface-light); border: none; width: 100%; border-radius: 4px; }
 .add-to-cart-btn-pdp.button:hover { background-color: #555; }
-body[data-theme="dark"] .add-to-cart-btn-pdp.button { background-color: var(--theme-text-dark); color: var(--theme-surface-light); }
-body[data-theme="dark"] .add-to-cart-btn-pdp.button:hover { background-color: var(--theme-text-light); color: #333; }
+body.dark-mode .add-to-cart-btn-pdp.button { background-color: var(--theme-text-dark); color: var(--theme-surface-light); }
+body.dark-mode .add-to-cart-btn-pdp.button:hover { background-color: var(--theme-text-light); color: #333; }
 
 .pdp-secondary-actions-links { margin-top: 1rem; display: flex; flex-wrap: wrap; gap: 0.5rem 1rem; font-size: 0.8em; justify-content: flex-start; }
 .pdp-action-link { background: none; border: none; color: var(--theme-text-muted); cursor: pointer; padding: 0.25rem 0; text-decoration: none;}

--- a/static/css/theme_moohaar_default.css
+++ b/static/css/theme_moohaar_default.css
@@ -37,7 +37,7 @@
     --shadow-lg: 0 6px 16px rgba(0,0,0,0.08); 
 }
 
-body[data-theme="dark"] .moohaar-theme-wrapper {
+body.dark-mode .moohaar-theme-wrapper {
     --theme-primary-blue: #7aa0cc; 
     --theme-secondary-orange: #f39c64; 
     --theme-neutral-dark-beige: #A0988B; 
@@ -132,11 +132,11 @@ body { font-family: var(--font-english); line-height: 1.6; margin: 0; padding: 0
 .announcement-item { width: 100%; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); opacity: 0; visibility: hidden; transition: opacity 0.5s ease-in-out, visibility 0s linear 0.5s; font-size: 1em; padding: 0.5rem 1rem; box-sizing: border-box;}
 .announcement-item.active { opacity: 1; visibility: visible; transition: opacity 0.5s ease-in-out, visibility 0s linear 0s; }
 .main-header-area { background-color: var(--theme-surface-light); color: var(--theme-text-dark); padding: 1rem 0; border-bottom: 1px solid var(--theme-border-light); box-shadow: var(--shadow-sm); transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease; }
-body[data-theme="dark"] .main-header-area { background-color: #242424; border-bottom-color: var(--theme-border-light); }
+body.dark-mode .main-header-area { background-color: #242424; border-bottom-color: var(--theme-border-light); }
 .main-header-area .container { display: flex; justify-content: space-between; align-items: center; }
 .logo-area-theme .logo-link-theme { text-decoration: none; }
 .logo-area-theme .logo-text-theme { font-family: Helvetica, Arial, sans-serif; font-size: 2.2em; font-weight: bold; color: var(--theme-primary-blue); display: block; transition: color 0.3s ease; }
-body[data-theme="dark"] .logo-area-theme .logo-text-theme { color: var(--theme-primary-blue); }
+body.dark-mode .logo-area-theme .logo-text-theme { color: var(--theme-primary-blue); }
 .logo-area-theme .tagline-theme { font-family: var(--font-urdu); font-size: 0.9em; color: var(--theme-text-muted); margin: 0; direction: rtl; text-align: left; transition: color 0.3s ease; }
 .desktop-nav { display: flex; align-items: center; gap: 1rem; margin-left:auto; }
 .desktop-nav a { text-decoration: none; color: var(--theme-text-dark); font-weight: bold; padding: 0.5rem 0.75rem; position: relative; border-radius: 4px; transition: color 0.3s ease, background-color 0.3s ease; }
@@ -144,9 +144,9 @@ body[data-theme="dark"] .logo-area-theme .logo-text-theme { color: var(--theme-p
 .desktop-nav a:hover::after { width: 70%; }
 .desktop-nav a:hover { color: var(--theme-secondary-orange); }
 .desktop-nav .theme-toggle-button { margin-left: 1rem; border: 1px solid var(--theme-text-dark); color: var(--theme-text-dark); background: none; padding: 0.4rem 0.6rem; border-radius: 20px; cursor: pointer; font-size: 0.9em; line-height: 1; transition: background-color 0.3s, color 0.3s, border-color 0.3s;}
-body[data-theme="dark"] .desktop-nav .theme-toggle-button { border-color: var(--theme-text-light); color: var(--theme-text-light); }
+body.dark-mode .desktop-nav .theme-toggle-button { border-color: var(--theme-text-light); color: var(--theme-text-light); }
 .desktop-nav .theme-toggle-button:hover { background-color: var(--theme-text-dark); color: var(--theme-surface-light); }
-body[data-theme="dark"] .desktop-nav .theme-toggle-button:hover { background-color: var(--theme-text-light); color: var(--theme-surface-light); }
+body.dark-mode .desktop-nav .theme-toggle-button:hover { background-color: var(--theme-text-light); color: var(--theme-surface-light); }
 .mobile-menu-toggle { display: none; flex-direction: column; justify-content: space-around; width: 30px; height: 24px; background: transparent; border: none; cursor: pointer; padding: 0; z-index: 1001; }
 .mobile-menu-toggle span { display: block; width: 100%; height: 3px; background-color: var(--theme-primary-blue); border-radius: 3px; transition: all 0.3s ease-in-out; }
 .mobile-menu-toggle.open span:nth-child(1) { transform: translateY(10.5px) rotate(45deg); }
@@ -157,14 +157,14 @@ body[data-theme="dark"] .desktop-nav .theme-toggle-button:hover { background-col
 .mobile-nav a { padding: 1rem 1.5rem; text-decoration: none; color: var(--theme-text-dark); font-size: 1.1em; border-bottom: 1px solid var(--theme-border-light); transition: background-color 0.2s ease, color 0.3s ease, border-color 0.3s ease; }
 .mobile-nav a:last-child { border-bottom: none; }
 .mobile-nav a:hover { background-color: var(--theme-neutral-light-beige); }
-body[data-theme="dark"] .mobile-nav a:hover { background-color: var(--theme-border-light); }
+body.dark-mode .mobile-nav a:hover { background-color: var(--theme-border-light); }
 main { flex-grow: 1; padding: 0 0 20px 0; }
 main .container { padding-top: 10px; padding-bottom: 10px; } 
 .storefront-main-content .container { padding-top: 0; padding-bottom: 2rem; } 
 .storefront-header-visual { display:none; }
 .hero-section { background-size: cover; background-position: center center; background-repeat: no-repeat; padding: 6rem 0; min-height: 70vh; position: relative; display: flex; align-items: center; color: var(--theme-text-light); transition: background-color 0.3s ease; }
 .hero-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.4); z-index: 1; }
-body[data-theme="dark"] .hero-overlay { background-color: rgba(0, 0, 0, 0.6); }
+body.dark-mode .hero-overlay { background-color: rgba(0, 0, 0, 0.6); }
 .hero-section .container { position: relative; z-index: 2; text-align: center; }
 .hero-content { max-width: 650px; margin: 0 auto; }
 .hero-headline { font-size: 3.5em; font-weight: 700; color: var(--theme-text-light); line-height: 1.15; margin-top: 0; margin-bottom: 1rem; text-shadow: 1px 1px 3px rgba(0,0,0,0.5); }
@@ -172,7 +172,7 @@ body[data-theme="dark"] .hero-overlay { background-color: rgba(0, 0, 0, 0.6); }
 .hero-cta-button-styled { background-color: var(--theme-secondary-orange); color: var(--theme-text-light); padding: 14px 35px; font-size: 1.1em; font-weight: bold; text-decoration: none; border-radius: 5px; transition: background-color 0.3s ease, transform 0.2s ease; border: none; display: inline-block; box-shadow: 0 2px 5px rgba(0,0,0,0.2); }
 .hero-cta-button-styled:hover { background-color: #e06520; transform: translateY(-2px); }
 .scrolling-text-bar { background-color: var(--theme-surface-light); color: var(--theme-text-dark); padding: 0.75rem 0; overflow: hidden; white-space: nowrap; border-top: 1px solid var(--theme-border-light); border-bottom: 1px solid var(--theme-border-light); box-shadow: var(--shadow-sm); transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;}
-body[data-theme="dark"] .scrolling-text-bar { background-color: var(--theme-surface-light); color: var(--theme-text-dark); border-top-color: var(--theme-border-light); border-bottom-color: var(--theme-border-light);}
+body.dark-mode .scrolling-text-bar { background-color: var(--theme-surface-light); color: var(--theme-text-dark); border-top-color: var(--theme-border-light); border-bottom-color: var(--theme-border-light);}
 .scrolling-text-content { display: inline-block; animation: scroll-text-continuous 25s linear infinite; will-change: transform; }
 .scrolling-text-content span { display: inline-block; margin: 0 2.5rem; font-size: 0.95em; font-weight: 500; }
 .scrolling-text-content span::before { content: "•"; margin-right: 2.5rem; color: var(--theme-secondary-orange); }
@@ -185,29 +185,29 @@ body[data-theme="dark"] .scrolling-text-bar { background-color: var(--theme-surf
 .category-card-image-wrapper { width: 100%; height: 180px; background-color: var(--theme-neutral-light-beige); }
 .category-card-image-wrapper img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .category-card-name { text-align: center; padding: 0.75rem 1rem; font-weight: bold; color: var(--theme-text-dark); background-color: rgba(255, 255, 255, 0.8); transition: background-color 0.3s ease, color 0.3s ease; }
-body[data-theme="dark"] .category-card { background-color: var(--theme-surface-light); border: 1px solid var(--theme-border-light); }
-body[data-theme="dark"] .category-card-name { color: var(--theme-text-dark); background-color: rgba(44, 44, 44, 0.7); }
+body.dark-mode .category-card { background-color: var(--theme-surface-light); border: 1px solid var(--theme-border-light); }
+body.dark-mode .category-card-name { color: var(--theme-text-dark); background-color: rgba(44, 44, 44, 0.7); }
 .promo-banners-section { padding: 3rem 0; }
 .promo-banner-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
 .promo-banner-card { display: flex; flex-direction: column; justify-content: center; align-items: center; position: relative; border-radius: 8px; overflow: hidden; min-height: 280px; background-size: cover; background-position: center; background-repeat: no-repeat; text-decoration: none; box-shadow: var(--shadow-md); transition: transform 0.3s ease, box-shadow 0.3s ease; padding: 1.5rem; text-align: center; color: var(--theme-text-light); }
 .promo-banner-card:hover { transform: translateY(-5px) scale(1.02); box-shadow: var(--shadow-lg); }
 .promo-banner-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.4); transition: background-color 0.3s ease; z-index: 1; }
 .promo-banner-card:hover .promo-banner-overlay { background-color: rgba(0, 0, 0, 0.55); }
-body[data-theme="dark"] .promo-banner-overlay { background-color: rgba(0,0,0,0.6); }
-body[data-theme="dark"] .promo-banner-card:hover .promo-banner-overlay { background-color: rgba(0,0,0,0.7); }
+body.dark-mode .promo-banner-overlay { background-color: rgba(0,0,0,0.6); }
+body.dark-mode .promo-banner-card:hover .promo-banner-overlay { background-color: rgba(0,0,0,0.7); }
 .promo-banner-content { position: relative; z-index: 2; }
 .promo-banner-content h3 { font-size: 1.8em; margin-top: 0; margin-bottom: 0.5rem; font-weight: bold; color: var(--theme-text-light); text-shadow: 1px 1px 3px rgba(0,0,0,0.6); }
 .promo-banner-content p { font-size: 1em; margin-bottom: 1.5rem; opacity: 0.95; color: var(--theme-text-light); text-shadow: 1px 1px 2px rgba(0,0,0,0.5); }
 .promo-banner-button.button.button-small { background-color: transparent; color: var(--theme-text-light); border: 2px solid var(--theme-text-light); padding: 8px 20px; font-size: 0.9em; font-weight: bold; transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease; }
 .promo-banner-button.button.button-small:hover { background-color: var(--theme-text-light); color: var(--theme-text-dark); border-color: var(--theme-text-light); }
-body[data-theme="dark"] .promo-banner-button.button.button-small { border-color: var(--theme-text-light); color: var(--theme-text-light); }
-body[data-theme="dark"] .promo-banner-button.button.button-small:hover { background-color: var(--theme-text-light); color: var(--theme-surface-light); border-color: var(--theme-text-light); }
+body.dark-mode .promo-banner-button.button.button-small { border-color: var(--theme-text-light); color: var(--theme-text-light); }
+body.dark-mode .promo-banner-button.button.button-small:hover { background-color: var(--theme-text-light); color: var(--theme-surface-light); border-color: var(--theme-text-light); }
 .storefront-product-grid-container { margin-top: 3rem; }
 .product-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1.75rem; }
 .storefront-product-card { background-color: var(--theme-surface-light); border-radius: 6px; box-shadow: var(--shadow-sm); border: 1px solid var(--theme-border-light); display: flex; flex-direction: column; text-align: left; overflow: hidden; transition: box-shadow 0.3s ease, transform 0.3s ease; position: relative; }
 .storefront-product-card:hover { transform: translateY(-5px); box-shadow: var(--shadow-md); }
 .product-image-wrapper { position: relative; overflow: hidden; width: 100%; padding-top: 100%; background-color: #f5f5f5; }
-body[data-theme="dark"] .product-image-wrapper { background-color: #333; }
+body.dark-mode .product-image-wrapper { background-color: #333; }
 .product-image { position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; display: block; transition: transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94); }
 .storefront-product-card:hover .product-image { transform: scale(1.03); }
 .badge.sale-badge { position: absolute; top: 10px; left: 10px; background-color: var(--theme-sale-badge-bg); color: var(--theme-sale-badge-text); padding: 0.3em 0.65em; border-radius: 3px; font-size: 0.7rem; font-weight: 700; z-index: 1; line-height: 1.2; text-transform: uppercase; letter-spacing: 0.5px; }
@@ -215,26 +215,26 @@ body[data-theme="dark"] .product-image-wrapper { background-color: #333; }
 .storefront-product-card:hover .product-quick-actions { opacity: 1; transform: translateX(0); }
 .quick-action-btn { background-color: rgba(255, 255, 255, 0.95); border: 1px solid var(--theme-border-light); border-radius: 50%; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; color: var(--theme-text-dark); font-size: 0.9em; cursor: pointer; box-shadow: var(--shadow-sm); transition: background-color 0.2s ease, color 0.2s ease; }
 .quick-action-btn:hover { background-color: var(--theme-text-dark); color: var(--theme-surface-light); }
-body[data-theme="dark"] .quick-action-btn { background-color: rgba(44, 44, 44, 0.9); color: var(--theme-text-light); border-color: var(--theme-border-light); }
-body[data-theme="dark"] .quick-action-btn:hover { background-color: var(--theme-text-light); color: var(--theme-surface-light); }
+body.dark-mode .quick-action-btn { background-color: rgba(44, 44, 44, 0.9); color: var(--theme-text-light); border-color: var(--theme-border-light); }
+body.dark-mode .quick-action-btn:hover { background-color: var(--theme-text-light); color: var(--theme-surface-light); }
 .product-info { padding: 1rem; text-align: center; flex-grow: 1; display: flex; flex-direction: column; }
 .product-name { font-size: 0.95em; font-weight: 500; color: var(--theme-text-dark); margin-top: 0.25rem; margin-bottom: 0.35rem; line-height: 1.4; transition: color 0.3s ease; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis; height: 2.8em; }
 .product-link:hover .product-name { color: var(--theme-secondary-orange); }
 .product-price { font-size: 1em; font-weight: 600; color: var(--theme-text-dark); margin-bottom: 0.5rem; transition: color 0.3s ease; }
-body[data-theme="dark"] .product-price { color: var(--theme-text-dark); }
+body.dark-mode .product-price { color: var(--theme-text-dark); }
 .product-color-swatches { display: flex; justify-content: center; gap: 0.4rem; margin-bottom: 0.75rem; height: 14px; }
 .product-color-swatches .swatch { width: 14px; height: 14px; border-radius: 50%; border: 1px solid var(--theme-border-light); cursor: pointer; }
 .product-card-actions { padding: 0 1rem 1rem 1rem; margin-top: auto; text-align: center; display: block; } 
 .add-to-cart-button.button.button-small { width: auto; display: inline-block; padding: 0.75em 1.5em; font-size: 0.9em; background-color: var(--theme-secondary-orange); color: var(--theme-text-light); border: none; border-radius: 4px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
 .add-to-cart-button.button.button-small:hover { background-color: #e06520; }
-body[data-theme="dark"] .add-to-cart-button.button.button-small { background-color: var(--theme-secondary-orange); }
-body[data-theme="dark"] .add-to-cart-button.button.button-small:hover { background-color: #D9681E; }
+body.dark-mode .add-to-cart-button.button.button-small { background-color: var(--theme-secondary-orange); }
+body.dark-mode .add-to-cart-button.button.button-small:hover { background-color: #D9681E; }
 
 /* === PRODUCT DETAIL PAGE STYLES === */
 .product-detail-page-wrapper.container { padding-top: 2rem; padding-bottom: 3rem; }
 .product-detail-grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; background-color: var(--theme-surface-light); padding: 1.5rem; border-radius: 8px; box-shadow: var(--shadow-md); transition: background-color 0.3s ease, box-shadow 0.3s ease; }
 .product-detail-image-column .main-image-display { margin-bottom: 1rem; border: 1px solid var(--theme-border-light); border-radius: 6px; overflow: hidden; background-color: #f9f9f9; position: relative; padding-top: 100%; }
-body[data-theme="dark"] .product-detail-image-column .main-image-display { border-color: var(--theme-border-light); background-color: #333; }
+body.dark-mode .product-detail-image-column .main-image-display { border-color: var(--theme-border-light); background-color: #333; }
 .product-detail-image-column .main-product-image { position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; display: block; }
 .product-detail-image-column .main-product-image.placeholder { object-fit: contain; padding: 2rem; }
 .product-thumbnails { display: flex; gap: 0.75rem; margin-top: 1rem; justify-content: flex-start; flex-wrap: wrap; }
@@ -250,14 +250,14 @@ body[data-theme="dark"] .product-detail-image-column .main-image-display { borde
 .product-meta .meta-link { color: var(--theme-primary-blue); text-decoration: none; }
 .product-meta .meta-link:hover { text-decoration: underline; }
 .availability-status .status-in-stock { color: #28a745; font-weight: 600; }
-body[data-theme="dark"] .availability-status .status-in-stock { color: #38c172; }
+body.dark-mode .availability-status .status-in-stock { color: #38c172; }
 .availability-status .status-out-of-stock { color: #dc3545; font-weight: 600; }
-body[data-theme="dark"] .availability-status .status-out-of-stock { color: #e3342f; }
+body.dark-mode .availability-status .status-out-of-stock { color: #e3342f; }
 .product-variants-section { margin-bottom: 1.5rem; border-top: 1px solid var(--theme-border-light); padding-top: 1.5rem; }
 .variant-option-group { margin-bottom: 1rem; }
 .variant-option-group label { display: block; margin-bottom: 0.5rem; font-weight: 600; font-size: 0.9em; }
 .variant-select, .quantity-input { width: 100%; padding: 0.75rem 1rem; border: 1px solid var(--theme-input-border-color); border-radius: 4px; font-size: 1em; background-color: var(--theme-surface-light); color: var(--theme-text-dark); box-sizing: border-box; }
-body[data-theme="dark"] .variant-select, body[data-theme="dark"] .quantity-input { background-color: var(--theme-bg-light); color: var(--theme-text-dark); }
+body.dark-mode .variant-select, body.dark-mode .quantity-input { background-color: var(--theme-bg-light); color: var(--theme-text-dark); }
 .color-swatches { display: flex; gap: 0.5rem; margin-top: 0.3rem; }
 .swatch-option { width: 24px; height: 24px; border-radius: 50%; border: 2px solid var(--theme-border-light); cursor: pointer; transition: transform 0.2s ease, border-color 0.2s ease; }
 .swatch-option.active, .swatch-option:hover { transform: scale(1.1); border-color: var(--theme-secondary-orange); }
@@ -267,8 +267,8 @@ body[data-theme="dark"] .variant-select, body[data-theme="dark"] .quantity-input
 .quantity-input { width: 70px; text-align: center; }
 .add-to-cart-button-detailpage.button { padding: 0.9rem 1.5rem; font-size: 1.05em; font-weight: bold; text-transform: uppercase; background-color: var(--theme-secondary-orange); color: var(--theme-text-light); border: none; width: 100%; }
 .add-to-cart-button-detailpage.button:hover { background-color: #e06520; }
-body[data-theme="dark"] .add-to-cart-button-detailpage.button { background-color: var(--theme-secondary-orange); }
-body[data-theme="dark"] .add-to-cart-button-detailpage.button:hover { background-color: #D9681E; }
+body.dark-mode .add-to-cart-button-detailpage.button { background-color: var(--theme-secondary-orange); }
+body.dark-mode .add-to-cart-button-detailpage.button:hover { background-color: #D9681E; }
 .product-page-secondary-actions { margin-top: 1rem; display: flex; gap: 1rem; }
 .action-link { background: none; border: none; color: var(--theme-text-muted); cursor: pointer; padding: 0.25rem 0; font-size: 0.9em; text-decoration: none;}
 .action-link:hover { color: var(--theme-primary-blue); text-decoration: underline; }
@@ -294,7 +294,7 @@ body[data-theme="dark"] .add-to-cart-button-detailpage.button:hover { background
 .social-media-links a { display: inline-block; margin-right: 0.75rem; color: var(--theme-footer-link); font-size: 1.4em; }
 .social-media-links a:hover { color: var(--theme-footer-link-hover); }
 .footer-bottom { background-color: rgba(0,0,0,0.15); padding: 1rem 0; text-align: center; font-size: 0.9em; color: var(--theme-footer-text); }
-body[data-theme="dark"] .footer-bottom { background-color: rgba(255,255,255,0.08); } 
+body.dark-mode .footer-bottom { background-color: rgba(255,255,255,0.08); } 
 .footer-bottom p { margin: 0; }
 
 /* === Responsive Adjustments === */
@@ -385,7 +385,7 @@ form.auth-form, main form { /* For platform auth forms, etc. */
     transition: background-color 0.3s ease, box-shadow 0.3s ease;
 }
 .dashboard-header h2, .my-stores-section h3 { margin-top: 0; font-size: 1.8em; color: var(--theme-primary-blue); }
-body[data-theme="dark"] .dashboard-header h2, body[data-theme="dark"] .my-stores-section h3 { color: var(--theme-primary-blue); }
+body.dark-mode .dashboard-header h2, body.dark-mode .my-stores-section h3 { color: var(--theme-primary-blue); }
 .store-list { list-style: none; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; }
 .store-item { background-color: var(--theme-surface-light); padding: 1.5rem; border-radius: 8px; box-shadow: var(--shadow-md); border: 1px solid var(--theme-border-light); display: flex; flex-direction: column; justify-content: space-between; }
 .store-item h4 { margin-top: 0; color: var(--theme-primary-blue); font-size: 1.3em; }

--- a/static/css/theme_selection_styles.css
+++ b/static/css/theme_selection_styles.css
@@ -123,9 +123,9 @@
 .theme-actions .button-manage:hover {
     background-color: #004d33;
 }
-html[data-theme="dark"] .theme-actions .button-manage {
+body.dark-mode .theme-actions .button-manage {
     background-color: var(--success-text);
 }
-html[data-theme="dark"] .theme-actions .button-manage:hover {
+body.dark-mode .theme-actions .button-manage:hover {
     background-color: #52c47c;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="{% static 'css/dashboard.css' %}">
 
     <style>
-        body { background: #fff; color: #000; }
+        body.light-mode { background: #fff; color: #000; }
         body.dark-mode { background: #000; color: #fff; }
         .light-dark-toggle {
             position: fixed;
@@ -26,7 +26,7 @@
 
     {% block extra_head %}{% endblock extra_head %}
 </head>
-<body class="moohaar-theme-wrapper" data-theme="light">
+<body class="moohaar-theme-wrapper light-mode">
     <button id="light-dark-toggle" class="light-dark-toggle" aria-label="Toggle light and dark mode">🌓</button>
 
     {% if user.is_authenticated %}
@@ -42,12 +42,6 @@
                     <a href="#" class="sidebar-link"><span>Settings</span> (soon)</a>
                     <a href="javascript:void(0);" onclick="document.getElementById('logout-form').submit();" class="sidebar-link"><span>Logout</span></a>
                 </nav>
-                <div class="sidebar-footer">
-                     <button class="theme-toggle-button" id="theme-toggle" title="Toggle theme" aria-label="Toggle theme">
-                        <span class="icon-light" style="display:none;">☀️</span>
-                        <span class="icon-dark" style="display:none;">🌙</span>
-                    </button>
-                </div>
             </aside>
             <div class="platform-main-content">
                 <main class="container">
@@ -89,67 +83,25 @@
         </footer>
     {% endif %}
 
-    <!-- Theme Toggle Script -->
-    <script>
-        const themeToggleButton = document.getElementById('theme-toggle');
-        const htmlElement = document.documentElement;
-        
-        function applyPlatformTheme(theme) {
-            htmlElement.setAttribute('data-theme', theme);
-            localStorage.setItem('platformTheme', theme);
-            if (themeToggleButton) {
-                const lightIcon = themeToggleButton.querySelector('.icon-light');
-                const darkIcon = themeToggleButton.querySelector('.icon-dark');
-                if (lightIcon && darkIcon) {
-                    if (theme === 'dark') {
-                        lightIcon.style.display = 'inline';
-                        darkIcon.style.display = 'none';
-                    } else {
-                        lightIcon.style.display = 'none';
-                        darkIcon.style.display = 'inline';
-                    }
-                }
-            }
-        }
-        
-        let preferredPlatformTheme = localStorage.getItem('platformTheme');
-        if (!preferredPlatformTheme) {
-            preferredPlatformTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
-        applyPlatformTheme(preferredPlatformTheme);
-
-        if (themeToggleButton) {
-            themeToggleButton.addEventListener('click', () => {
-                const currentTheme = htmlElement.getAttribute('data-theme');
-                const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-                applyPlatformTheme(newTheme);
-            });
-        }
-    </script>
-
     <script>
         (function() {
             const toggle = document.getElementById('light-dark-toggle');
             const body = document.body;
 
             function applyTheme(theme) {
-                if (theme === 'dark') {
-                    body.classList.add('dark-mode');
-                } else {
-                    body.classList.remove('dark-mode');
-                }
+                body.classList.remove('light-mode', 'dark-mode');
+                body.classList.add(`${theme}-mode`);
                 localStorage.setItem('preferredTheme', theme);
             }
 
             const stored = localStorage.getItem('preferredTheme');
-            if (stored) {
-                applyTheme(stored);
-            }
+            const initial = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+            applyTheme(initial);
 
             if (toggle) {
                 toggle.addEventListener('click', function () {
-                    const isDark = body.classList.toggle('dark-mode');
-                    localStorage.setItem('preferredTheme', isDark ? 'dark' : 'light');
+                    const newTheme = body.classList.contains('dark-mode') ? 'light' : 'dark';
+                    applyTheme(newTheme);
                 });
             }
         })();

--- a/templates/storefront/storefront_base.html
+++ b/templates/storefront/storefront_base.html
@@ -14,7 +14,7 @@
     
     {% block extra_head %}{% endblock extra_head %} {# This is where product_detail_styles.css will be linked #}
 </head>
-<body data-theme="light" class="moohaar-theme-wrapper"> 
+<body class="moohaar-theme-wrapper light-mode">
 
     {% block theme_header %}
     <header class="storefront-site-header">
@@ -95,16 +95,51 @@
         const storefrontThemeToggleButton = document.getElementById('storefront-theme-toggle-button');
         const mobileMenuToggleButton = document.getElementById('mobile-menu-toggle-button');
         const mobileNav = document.getElementById('mobile-navigation-menu');
-        const bodyElementForTheme = document.body; 
-        function applyStorefrontTheme(theme) { /* ... existing JS ... */ }
-        let preferredStorefrontTheme = localStorage.getItem('storefrontTheme');
-        if (!preferredStorefrontTheme) { preferredStorefrontTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'; }
-        applyStorefrontTheme(preferredStorefrontTheme);
-        if (storefrontThemeToggleButton) { /* ... existing JS ... */ }
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => { if (!localStorage.getItem('storefrontTheme')) { applyStorefrontTheme(event.matches ? 'dark' : 'light'); } });
-        if (mobileMenuToggleButton && mobileNav) { /* ... existing JS ... */ }
-        document.addEventListener('DOMContentLoaded', function() { /* ... existing announcement slider JS ... */ });
-    </script> {# For brevity, I've collapsed the JS here, but ensure you have the full correct JS from before #}
+        const bodyElementForTheme = document.body;
+
+        function applyStorefrontTheme(theme) {
+            bodyElementForTheme.classList.remove('light-mode', 'dark-mode');
+            bodyElementForTheme.classList.add(`${theme}-mode`);
+            localStorage.setItem('storefrontTheme', theme);
+        }
+
+        const storedTheme = localStorage.getItem('storefrontTheme');
+        const initialTheme = storedTheme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        applyStorefrontTheme(initialTheme);
+
+        if (storefrontThemeToggleButton) {
+            storefrontThemeToggleButton.addEventListener('click', () => {
+                const newTheme = bodyElementForTheme.classList.contains('dark-mode') ? 'light' : 'dark';
+                applyStorefrontTheme(newTheme);
+            });
+        }
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            if (!localStorage.getItem('storefrontTheme')) {
+                applyStorefrontTheme(event.matches ? 'dark' : 'light');
+            }
+        });
+
+        if (mobileMenuToggleButton && mobileNav) {
+            mobileMenuToggleButton.addEventListener('click', () => {
+                const expanded = mobileMenuToggleButton.getAttribute('aria-expanded') === 'true';
+                mobileMenuToggleButton.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+                mobileNav.classList.toggle('open');
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            const slider = document.getElementById('announcementSlider');
+            if (!slider) return;
+            const items = slider.querySelectorAll('.announcement-item');
+            let index = 0;
+            setInterval(() => {
+                items[index].classList.remove('active');
+                index = (index + 1) % items.length;
+                items[index].classList.add('active');
+            }, 3000);
+        });
+    </script>
     {% block extra_scripts %}{% endblock extra_scripts %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep a single theme toggle button at the top right
- apply `light-mode` / `dark-mode` class on `<body>`
- persist selected theme to `localStorage`
- update admin and storefront templates
- update CSS to use the new body classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68835dc40710832e8c17750a5a3e83fe