### PR TITLE
Show store info in dashboard

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -20,15 +20,18 @@ class CustomLoginView(LoginView):
 
 @login_required
 def user_dashboard(request):
-    # Check if the user has any stores
-    user_stores = Store.objects.filter(user=request.user)
-    if not user_stores.exists():
-        messages.info(request, "You don't have a store yet. Let's create one!")
-        return redirect('stores:create_store')
+    """Display the dashboard for the logged in user.
 
-    # If stores exist, display them on the dashboard
+    If the user has created a store (their StoreProfile), display the store
+    details.  Otherwise show a call to action to create one.
+    """
+
+    store_profile = Store.objects.filter(user=request.user).first()
+    if not store_profile:
+        messages.info(request, "You don't have a store yet. Create one to get started!")
+
     context = {
-        'stores': user_stores.order_by('-created_at')
+        'store_profile': store_profile,
     }
     return render(request, 'accounts/user_dashboard.html', context)
 

--- a/templates/accounts/user_dashboard.html
+++ b/templates/accounts/user_dashboard.html
@@ -20,6 +20,23 @@
 
 {% block content %}
 <div class="animated fadeIn">
+    <div class="row mb-4">
+        <div class="col-lg-6">
+            {% if store_profile %}
+            <div class="card">
+                <div class="card-header"><strong>Your Store</strong></div>
+                <div class="card-body">
+                    <p><strong>Store ID:</strong> {{ store_profile.id }}</p>
+                    <p><strong>Store Name:</strong> {{ store_profile.name }}</p>
+                    <p><strong>Phone Number:</strong> {{ store_profile.store_phone_number|default:"-" }}</p>
+                    <p><strong>WhatsApp Number:</strong> {{ store_profile.store_whatsapp_number|default:"-" }}</p>
+                </div>
+            </div>
+            {% else %}
+            <a href="{% url 'stores:create_store' %}" class="btn btn-primary">Create Your Store</a>
+            {% endif %}
+        </div>
+    </div>
     <div class="row">
         {# ... your existing 4 stat widgets here ... #}
     </div>


### PR DESCRIPTION
## Summary
- display store details on the user dashboard instead of redirecting
- add a call to create a store when none exists

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6883bb8c9acc832e86cb055ca3bfa937