### PR TITLE
Fix EMAIL_BACKEND line in settings

### DIFF
--- a/mystore_project/settings.py
+++ b/mystore_project/settings.py
@@ -139,4 +139,5 @@ LOGOUT_REDIRECT_URL = 'platform_home' # Redirect to landing page after logout
 CART_SESSION_ID = 'cart'
 
 # Email configuration for development (prints emails to console)
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'\nCORS_ALLOW_ALL_ORIGINS = True
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+CORS_ALLOW_ALL_ORIGINS = True


### PR DESCRIPTION
## Summary
- split `EMAIL_BACKEND` and `CORS_ALLOW_ALL_ORIGINS` into separate lines

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68844ae45c48832e86dd3b6299243b20