### PR TITLE
Add static reference checker and fix broken assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ db.sqlite3
 
 # React build
 frontend/node_modules/
-frontend/dist/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Instructions for a software engineer to set up and run the project locally.
     ```
     The application will be available at `http://127.0.0.1:8000/`.
 
+7.  **Before deploying**, run the static reference check and collect static
+    files:
+    ```bash
+    python manage.py check_static_references
+    python manage.py collectstatic --noinput
+    ```
+
 ---
 
 ## 🗺️ Future Roadmap

--- a/mystore_project/settings.py
+++ b/mystore_project/settings.py
@@ -120,7 +120,13 @@ STATIC_ROOT = BASE_DIR / 'staticfiles' # For production
 STATICFILES_DIRS = [
     BASE_DIR / 'static', # For development
 ]
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+# Use hashed static files with Whitenoise. Switch to CompressedStaticFilesStorage
+# by setting STATICFILES_STORAGE=whitenoise.storage.CompressedStaticFilesStorage
+# via environment variable if Manifest build issues occur.
+STATICFILES_STORAGE = os.environ.get(
+    'STATICFILES_STORAGE',
+    'whitenoise.storage.CompressedManifestStaticFilesStorage'
+)
 # Media files (User-uploaded content)
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'

--- a/static/user_dashboard/assets/scss/style.css
+++ b/static/user_dashboard/assets/scss/style.css
@@ -1598,11 +1598,7 @@ header .form-inline {
   padding: 10px 0 0 35px;
   color: #fff; }
 
-.black-ribon {
-  background: url("../../images/twitter_corner_black.png") no-repeat; }
 
-.blue-ribon {
-  background: url("../../images/twitter_corner_blue.png") no-repeat; }
 
 .twt-feed .wtt-mark {
   color: rgba(255, 255, 255, 0.15);

--- a/stores/management/commands/check_static_references.py
+++ b/stores/management/commands/check_static_references.py
@@ -1,0 +1,62 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+import os
+import re
+from pathlib import Path
+
+class Command(BaseCommand):
+    help = "Scan templates and CSS for static file references and verify files exist"
+
+    template_pattern = re.compile(r"{%%\s*static ['\"](?P<path>[^'\"]+)['\"]\s*%%}")
+    css_pattern = re.compile(r"url\((?:'|\")?(?P<path>static/[^)'\"]+)")
+
+    def handle(self, *args, **options):
+        base_dirs = [
+            Path(settings.BASE_DIR) / 'static',
+            Path(settings.BASE_DIR) / 'frontend' / 'dist' / 'assets',
+        ]
+        missing = []
+
+        def exists(rel_path):
+            rel_path = rel_path.split('?', 1)[0].split('#', 1)[0]
+            for base in base_dirs:
+                if (base / rel_path).exists():
+                    return True
+            return False
+
+        # Scan templates
+        templates_dir = Path(settings.BASE_DIR) / 'templates'
+        for root, _, files in os.walk(templates_dir):
+            for fname in files:
+                if not fname.endswith(('.html', '.htm', '.txt')):
+                    continue
+                fpath = Path(root) / fname
+                with open(fpath, encoding='utf-8') as fh:
+                    for lineno, line in enumerate(fh, start=1):
+                        for match in self.template_pattern.finditer(line):
+                            rel = match.group('path')
+                            if not exists(rel):
+                                missing.append(f"{fpath}:{lineno} -> {rel}")
+
+        # Scan CSS files
+        css_files = []
+        for base in base_dirs:
+            if base.exists():
+                for root, _, files in os.walk(base):
+                    for fname in files:
+                        if fname.endswith('.css'):
+                            css_files.append(Path(root) / fname)
+        for css_file in css_files:
+            with open(css_file, encoding='utf-8') as fh:
+                for lineno, line in enumerate(fh, start=1):
+                    for match in self.css_pattern.finditer(line):
+                        rel = match.group('path')[len('static/'):]  # remove leading static/
+                        if not exists(rel):
+                            missing.append(f"{css_file}:{lineno} -> {rel}")
+
+        if missing:
+            missing_report = '\n'.join(missing)
+            self.stderr.write(self.style.ERROR('Missing static file references found:'))
+            self.stderr.write(missing_report)
+            raise CommandError('Static reference check failed')
+        self.stdout.write(self.style.SUCCESS('All static references are valid'))


### PR DESCRIPTION
## Summary
- remove `frontend/dist/` from `.gitignore` so built assets are kept
- disable unused image references in user dashboard SCSS
- allow overriding `STATICFILES_STORAGE` with an env var
- add management command `check_static_references`
- document running the new command before deployment

## Testing
- `python manage.py check_static_references`
- `python manage.py collectstatic --noinput`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68844f7255e4832ea52ab7a11ed0e8a2