### PR TITLE
Add dark mode toggle in header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,38 +1,10 @@
-import { useEffect, useState } from 'react'
 import './index.css'
+import Header from './Header.jsx'
 
 function App() {
-  const [theme, setTheme] = useState('light')
-
-  useEffect(() => {
-    const stored = localStorage.getItem('theme')
-    if (stored) {
-      setTheme(stored)
-      document.documentElement.classList.toggle('dark', stored === 'dark')
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setTheme('dark')
-      document.documentElement.classList.add('dark')
-    }
-  }, [])
-
-  useEffect(() => {
-    localStorage.setItem('theme', theme)
-    document.documentElement.classList.toggle('dark', theme === 'dark')
-  }, [theme])
-
-  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark')
-
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-white p-8">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold">Dashboard</h1>
-        <button
-          onClick={toggleTheme}
-          className="px-3 py-1 rounded border border-gray-300 dark:border-gray-700"
-        >
-          Toggle {theme === 'dark' ? 'Light' : 'Dark'} Mode
-        </button>
-      </div>
+      <Header />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="p-4 rounded bg-gray-100 dark:bg-gray-800">Sales: 123</div>
         <div className="p-4 rounded bg-gray-100 dark:bg-gray-800">Orders: 45</div>

--- a/frontend/src/Header.jsx
+++ b/frontend/src/Header.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+
+export default function Header() {
+  const [theme, setTheme] = useState('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored) {
+      setTheme(stored)
+      document.documentElement.classList.toggle('dark', stored === 'dark')
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+      document.documentElement.classList.add('dark')
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('theme', theme)
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+  }, [theme])
+
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark')
+
+  return (
+    <div className="flex justify-between items-center mb-6">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <button
+        onClick={toggleTheme}
+        className="px-3 py-1 rounded border border-gray-300 dark:border-gray-700"
+      >
+        Toggle {theme === 'dark' ? 'Light' : 'Dark'} Mode
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `Header` component with dark mode logic
- simplify `App` component to use new header

## Testing
- `npm run lint` *(fails: `no-undef` error in tailwind.config.js)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68858e74a724832e8d740790320932be