### PR TITLE
Fix invalid quotes in serializers

### DIFF
--- a/stores/serializers.py
+++ b/stores/serializers.py
@@ -4,11 +4,11 @@ from .models import StoreProfile, Product
 class StoreProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = StoreProfile
-        fields = [‘name’, ‘phone_number’, ‘whatsapp_number’]
+        fields = ['name', 'phone_number', 'whatsapp_number']
 
 class ProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
-        fields = [‘name’, ‘image’, ‘price’]
+        fields = ['name', 'image', 'price']
 
 


### PR DESCRIPTION
## Summary
- standardize quote characters in `stores/serializers.py`

## Testing
- `python manage.py test` *(fails: module 'stores.views' has no attribute 'create_store')*

------
https://chatgpt.com/codex/tasks/task_e_68860dbd3320832ebe3c9ecac0a976e7