### PR TITLE
Add placeholder create_store view

### DIFF
--- a/stores/views.py
+++ b/stores/views.py
@@ -1,6 +1,12 @@
+from django.http import HttpResponse
 from rest_framework import generics
 from .models import StoreProfile, Product
 from .serializers import StoreProfileSerializer, ProductSerializer
+
+# Placeholder view for creating a store
+def create_store(request):
+    """Temporary endpoint for creating stores."""
+    return HttpResponse("Store creation endpoint")
 
 # API Views
 class StoreProfileAPIView(generics.RetrieveAPIView):


### PR DESCRIPTION
## Summary
- implement a simple `create_store` view in `stores.views`
- import `HttpResponse` as recommended

## Testing
- `python manage.py check` *(fails: `module 'stores.views' has no attribute 'store_detail'`)*

------
https://chatgpt.com/codex/tasks/task_e_68861045b4e4832eab5802443e3eb947